### PR TITLE
为了解决k8s中readOnlyRootFilesystem=true时,无法启动ui界面

### DIFF
--- a/FreeScheduler/Dashboard/StaticFiles.cs
+++ b/FreeScheduler/Dashboard/StaticFiles.cs
@@ -24,10 +24,14 @@ namespace FreeScheduler.Dashboard
 					if (_isStaticFiles == false)
 					{
 						var curPath = AppDomain.CurrentDomain.BaseDirectory;
-						var zipPath = $"{curPath}/{Guid.NewGuid()}.zip";
+                        //这里做了修改,增加了一层目录.主要是为了解决k8s中readOnlyRootFilesystem=true;
+                        var zipPath = $"{curPath}/wwwzip/{Guid.NewGuid()}.zip";
 						using (var zip = WwwrootStream())
 						{
-							using (var fs = File.Open(zipPath, FileMode.OpenOrCreate))
+							//盘算wwwzip是否存在,不存在就创建
+                            if (!Directory.Exists(System.IO.Path.GetDirectoryName(zipPath))) Directory.CreateDirectory(System.IO.Path.GetDirectoryName(zipPath));
+
+                            using (var fs = File.Open(zipPath, FileMode.OpenOrCreate))
 							{
 								zip.CopyTo(fs);
 								fs.Close();


### PR DESCRIPTION
k8s设置了readOnlyRootFilesystem=true时导致程序运行目录只读属性,无法下载UI压缩包到运行目录,从而导致Pod无法启动.

![Image](https://github.com/user-attachments/assets/0280fa90-53ff-4179-91c7-01a4b9f6305c)

有了wwwzip这一层目录,就可以设置Pod中的存储挂载,/data/zip/:/app/wwwzip/,经过目录挂载映射就可以让这个目录有写权限,但是不破坏/app只读属性